### PR TITLE
53 fix feedback tas feedback re check multicollinearity

### DIFF
--- a/src/linreg_ally/multicollinearity.py
+++ b/src/linreg_ally/multicollinearity.py
@@ -63,7 +63,8 @@ def check_multicollinearity(train_df: pd.DataFrame, threshold = None, vif_only =
         x='level_0',
         y='level_1',
         size='corr',
-        color='corr'
+        color='corr',
+        tooltip=['level_0', 'level_1', 'corr'] 
     )
 
     # Filter VIF dataframe by the threshold if provided

--- a/src/linreg_ally/multicollinearity.py
+++ b/src/linreg_ally/multicollinearity.py
@@ -31,12 +31,20 @@ def check_multicollinearity(train_df: pd.DataFrame, threshold = None, vif_only =
     alt.Chart
         A chart that shows the pairwise Pearson Correlations of all numeric columns in train_df. 
 
+    Raises
+    ------
+    TypeError
+        If `train_df` is not a pandas DataFrame.
+
     Examples
     --------
     >>> from linreg_ally.multicollinearity import check_multicollinearity
     >>> vif_df, corr_chart = check_multicollinearity(train_df)
     >>> vif_df = check_multicollinearity(train_df, threshold = 5, vif_only = True)  
     """
+    if not isinstance(train_df, pd.DataFrame):
+        raise TypeError(f"Expect train_df to be a pd.Dataframe but got {type(train_df)}")
+    
     # select only numeric columns in train_df
     train_df_numeric_only = train_df.select_dtypes(include='number')
 

--- a/tests/test_multicollinearity.py
+++ b/tests/test_multicollinearity.py
@@ -14,7 +14,9 @@ data = {
 train_df = pd.DataFrame(data)
 
 def test_function_output_with_perfect_correlation():
-
+    """
+    Test use case when train data has perfect and moderate correlation.
+    """
     vif_df, corr_chart = check_multicollinearity(train_df) 
 
     vif_df_len = 4 
@@ -32,6 +34,9 @@ def test_function_output_with_perfect_correlation():
     assert corr_chart.encoding.size.shorthand == 'corr'
 
 def test_vif_value(): 
+    """
+    Test VIF values in vif_df created by the function. 
+    """
     vif_df = check_multicollinearity(train_df, vif_only=True) 
 
     vif_0 = variance_inflation_factor(train_df, 0)
@@ -45,6 +50,9 @@ def test_vif_value():
     assert vif_df.iloc[3,1] == vif_3   
 
 def test_threshold():
+    """
+    Test if VIF values in vif_df are greater than or equal to the specified threshold.
+    """
     vif_df = check_multicollinearity(train_df, threshold=15, vif_only=True)
     threshold = 15
 

--- a/tests/test_multicollinearity_wrong_input.py
+++ b/tests/test_multicollinearity_wrong_input.py
@@ -19,13 +19,25 @@ data_numeric_only = {
     #"Feature_4": ['a', 'b', 'c', 'd', 'e']   # string column
 }
 
+list_data = [1, 2, 3, 4, 5]
+
 train_df_with_str = pd.DataFrame(data_with_str)
 train_df_numeric_only = pd.DataFrame(data_numeric_only)
 
 def test_function_output_incorrect_dtype():
+    """
+    Test when input is not a dataframe. 
+    """
+    with pytest.raises(TypeError):
+        check_multicollinearity(list_data) 
+
+
+def test_function_output_incorrect_dtype():
+    """
+    Test when input dataframe has a column with str datatype. 
+    """
 
     vif_df = check_multicollinearity(train_df_with_str, vif_only=True) 
-
 
     vif_df_len = 3 
     vif_column_type = 'float64'

--- a/tests/test_multicollinearity_wrong_input.py
+++ b/tests/test_multicollinearity_wrong_input.py
@@ -24,7 +24,7 @@ list_data = [1, 2, 3, 4, 5]
 train_df_with_str = pd.DataFrame(data_with_str)
 train_df_numeric_only = pd.DataFrame(data_numeric_only)
 
-def test_function_output_incorrect_dtype():
+def test_list_as_function_input():
     """
     Test when input is not a dataframe. 
     """
@@ -32,7 +32,7 @@ def test_function_output_incorrect_dtype():
         check_multicollinearity(list_data) 
 
 
-def test_function_output_incorrect_dtype():
+def test_dataframe_with_str_column():
     """
     Test when input dataframe has a column with str datatype. 
     """


### PR DESCRIPTION
Addressed the following comments: 

1. "check_multicollinearity" function did not check if input variables are of the correct datatype.

2. For "test_multicollinearity_wrong_input.py" did not test for if the input variabales are as expected, and if errors are raised when the input variable is not of an expected data type (e.g., expect train_df as dataframe but user uses a list)

3. ("tests/test_multicollinearity.py", "tests/test_multicollinearity_wrong_input.py") are not well documented.