### PR TITLE
Add README badges

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -65,7 +65,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v8.3.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # linreg_ally
 
 [![Documentation Status](https://readthedocs.org/projects/linreg-ally/badge/?version=latest)](https://linreg-ally.readthedocs.io/en/latest/?badge=latest)
+[![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-31111/)
+[![codecov](https://codecov.io/gh/UBC-MDS/linreg_ally/graph/badge.svg?token=JfomN9gPnY)](https://codecov.io/gh/UBC-MDS/linreg_ally)
 
 ## Overview of linreg_ally package:	 
 


### PR DESCRIPTION
This PR has added in the badges requested by reviewers. The badges added are the Python 3.11 badge and the CodeCov badge. Corresponding repository secrets are added as well.

The package version is not added yet because that should be added right before the creation of the release.