### PR TITLE
Fix version number and author names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "linreg_ally"
-version = "0.0.2"
+version = "1.1.0"
 description = "A package to test linearity assumptions to determine whether a linear regression model is good or not"
-authors = ["Paramveer, Merari, Cheng, Alex"]
+authors = ["Paramveer Singh", "Merari Santana-Carbajal", "Cheng Zhang", "Alex Wong"]
 license = "MIT"
 readme = "README.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "linreg_ally"
-version = "1.1.0"
+version = "1.1.15"
 description = "A package to test linearity assumptions to determine whether a linear regression model is good or not"
 authors = ["Paramveer Singh", "Merari Santana-Carbajal", "Cheng Zhang", "Alex Wong"]
 license = "MIT"


### PR DESCRIPTION
This PR addresses the version mismatch that occurred due to the CD job not running. The author names are also now full names to show up on the PyPI release.